### PR TITLE
Remove pointless check from decorrupt

### DIFF
--- a/scripts/decorrupt.js
+++ b/scripts/decorrupt.js
@@ -12,9 +12,9 @@ function (c,a) {
     while (r.test(o.join(""))) {
         // iterate over a fresh output
         d().forEach((p, i) => {
-            // if the origin output has corruption and the new doesn't,
+            // if the origin output has corruption,
             // replace the corrpution with the proper char
-            if (r.test(o[i]) && !(r.test(p)))
+            if (r.test(o[i]))
                     o[i] = p
         })
     }


### PR DESCRIPTION
It doesn't actually matter if the new output is corrupted or not. Writing new corruption over the old won't hurt us.