### PR TITLE
Use a character set instead of (t|h|i|s)

### DIFF
--- a/scripts/decorrupt.js
+++ b/scripts/decorrupt.js
@@ -1,6 +1,6 @@
 function (c,a) {
         // Corruption char regex
-    let r = /(¡|¢|£|¤|¥|¦|§|¨|©|ª|Ã|Á)/,
+    let r = /[¡¢£¤¥¦§¨©ªÃÁ]/,
         // Regex to strip colors
         s = /`\w(.)`/g,
         // Script caller command


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp