### PR TITLE
Using scripts.lib for corruption chars

### DIFF
--- a/scripts/decorrupt.js
+++ b/scripts/decorrupt.js
@@ -1,6 +1,6 @@
 function (c,a) {
-        // Corruption char regex
-    let r = /[¡¢£¤¥¦§¨©ªÃÁ]/,
+    // Corruption char regex using scripts.lib()
+    let r = new RegExp(`[${#fs.scripts.lib().corruption_chars}]`),
         // Regex to strip colors
         s = /`\w(.)`/g,
         // Script caller command


### PR DESCRIPTION
This allows us to stay up-to-date with the current corruption chars if
they should ever change.