### PR TITLE
Resolve an issue when no args are passed

### DIFF
--- a/scripts/npcs.js
+++ b/scripts/npcs.js
@@ -99,7 +99,7 @@ function (c,a) { // sec:"all"
     })
 
     // return avail or avail[level] if a.object is true
-    if (a.object) {
+    if (a && a.object) {
         if (a.sec) {
             if (map_args[a.sec])
                 // https://stackoverflow.com/a/11508530


### PR DESCRIPTION
Without this running the script directly with no args (a being null)
results in "TypeError: Cannot read property 'object' of null". This
resolves the issue by only accessing a.object when there are any args
passed.